### PR TITLE
Fix Regular Expression injection

### DIFF
--- a/ebook_homebrew/core.py
+++ b/ebook_homebrew/core.py
@@ -87,7 +87,7 @@ class Common(object):
         Returns:
             Match: If filename contains digit, return Match object, others return false.
         """
-        match_obj = re.search("\\d{" + str(digits) + "}", filename)
+        match_obj = re.search("\\d{" + re.escape(str(digits)) + "}", filename)
         return match_obj
 
     @staticmethod


### PR DESCRIPTION
The fact of not sanitizing user input appended to a regular expression may lead to a `Regular Expression Denegation of Service` by an attacker crafting a regular expression taking too much to load, or simply change the behaviour of the program.

Vulnerable code:

https://github.com/tubone24/ebook_homebrew/blob/7df72331e9636ad2821543144c8aef02d40b7e23/ebook_homebrew/core.py#L90

References:

[OWASP ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)